### PR TITLE
use ISO 8601 for timestamp

### DIFF
--- a/gatelogue-aggregator/src/gatelogue_aggregator/types/context.py
+++ b/gatelogue-aggregator/src/gatelogue_aggregator/types/context.py
@@ -77,7 +77,7 @@ class Context(AirContext, RailContext, SeaContext, BusContext, ToSerializable):
         """A :py:class:`SeaContext` object"""
         bus: SeaContext.Ser
         """A :py:class:`BusContext` object"""
-        timestamp: str = msgspec.field(default_factory=lambda: datetime.datetime.now().strftime("%Y%m%d-%H%:M%:S%Z"))  # noqa: DTZ005
+        timestamp: str = msgspec.field(default_factory=lambda: datetime.datetime.now().isoformat())  # noqa: DTZ005
         """Time that the aggregation of the data was done"""
         version: int = 1
         """Version number of the database format"""


### PR DESCRIPTION
it's generally easier to parse & display